### PR TITLE
Remove unnecessary jaxb dependencies.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -17,7 +17,7 @@ ihmc {
 
 dependencies {
    api("net.sf.trove4j:trove4j:3.0.3")
-   api("com.sun.xml.bind:jaxb-ri:4.0.5")
+   api("com.sun.xml.bind:jaxb-impl:4.0.5")
 
    api("us.ihmc:ihmc-commons:0.32.0")
    api("us.ihmc:euclid-frame:0.21.0")


### PR DESCRIPTION
Kept getting this error for dependent projects:
```
 Could not resolve all files for configuration ':scs2-definition:compileClasspath'.
   > Could not find jaxb-release-documentation-4.0.5-docbook.jar (com.sun.xml.bind:jaxb-release-documentation:4.0.5).
     Searched in the following locations:
         https://repo.maven.apache.org/maven2/com/sun/xml/bind/jaxb-release-documentation/4.0.5/jaxb-release-documentation-4.0.5-docbook.jar
```
Since we don't need that, I've reduced from
```
|    +--- com.sun.xml.bind:jaxb-ri:4.0.5
|    |    +--- jakarta.xml.bind:jakarta.xml.bind-api:4.0.2
|    |    |    \--- jakarta.activation:jakarta.activation-api:2.1.3
|    |    +--- com.sun.xml.bind:jaxb-core:4.0.5
|    |    |    +--- jakarta.xml.bind:jakarta.xml.bind-api:4.0.2 (*)
|    |    |    \--- org.eclipse.angus:angus-activation:2.0.2
|    |    |         \--- jakarta.activation:jakarta.activation-api:2.1.3
|    |    +--- com.sun.xml.bind:jaxb-impl:4.0.5
|    |    |    \--- com.sun.xml.bind:jaxb-core:4.0.5 (*)
|    |    +--- com.sun.xml.bind:jaxb-xjc:4.0.5
|    |    |    \--- com.sun.xml.bind:jaxb-core:4.0.5 (*)
|    |    +--- com.sun.xml.bind:jaxb-jxc:4.0.5
|    |    |    +--- com.sun.xml.bind:jaxb-impl:4.0.5 (*)
|    |    |    \--- com.sun.xml.bind:jaxb-xjc:4.0.5 (*)
|    |    +--- com.sun.xml.bind:jaxb-release-documentation:4.0.5
|    |    \--- com.sun.xml.bind:jaxb-samples:4.0.5

```
to
```
|    +--- com.sun.xml.bind:jaxb-impl:4.0.5
|    |    \--- com.sun.xml.bind:jaxb-core:4.0.5
|    |         +--- jakarta.xml.bind:jakarta.xml.bind-api:4.0.2
|    |         |    \--- jakarta.activation:jakarta.activation-api:2.1.3
|    |         \--- org.eclipse.angus:angus-activation:2.0.2
|    |              \--- jakarta.activation:jakarta.activation-api:2.1.3
```